### PR TITLE
Stop warning for Elixir 1.4

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,8 +6,8 @@ defmodule Fluent.Mixfile do
      version: "0.1.0",
      elixir: ">= 1.0.0",
      description: "fluentd client library",
-     package: package,
-     deps: deps]
+     package: package(),
+     deps: deps()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
Just because there are some warnings we could get rid of very easily :)